### PR TITLE
Remove font-smoothing override

### DIFF
--- a/xp.css
+++ b/xp.css
@@ -6,7 +6,6 @@ body {
   background-attachment: fixed;
   padding-top: 60px;
   padding-bottom: 80px;
-  -webkit-font-smoothing: none;
 }
 
 /* Header */


### PR DESCRIPTION
Without antialiasing, fonts look like garbage on Mac Chrome 67